### PR TITLE
Switch project to Python 3.11 with pip

### DIFF
--- a/.cursor/rules/chanscope-deployment.mdc
+++ b/.cursor/rules/chanscope-deployment.mdc
@@ -158,15 +158,11 @@ When working with `docker-compose.test.yml`, ensure:
 
 - **Entry Point**: Configure in `replit.nix` or `.replit`:
   ```
-  run = "poetry run uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}"
+  run = "python -m uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}"
   ```
 
 - **Poetry Setup**:
   ```
-  [tool.poetry]
-  name = "chanscope"
-  version = "0.1.0"
-  description = "Chanscope application for semantic search and inference"
   ```
 
 - **Dependencies**:
@@ -194,7 +190,7 @@ When working with `docker-compose.test.yml`, ensure:
 ### 5. Testing on Replit
 
 - **Test Execution**:
-  - Create a dedicated test entry point: `poetry run pytest`
+  - Create a dedicated test entry point: `python -m pytest`
   - Use environment variable `TEST_MODE=true` for test runs
   - Implement test fixtures that clean up after themselves
 
@@ -298,7 +294,7 @@ git clone https://github.com/your-org/chanscope.git
 # 3. Install dependencies with Poetry
 
 # Start the application
-poetry run uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}
+python -m uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}
 ```
 
 ### 3. Testing Before Deployment
@@ -515,8 +511,8 @@ services:
         target: /app/data
       # Persistent volumes
       - type: volume
-        source: poetry_cache
-        target: /app/.cache/pypoetry
+        source: pip_cache
+        target: /app/.cache/pip
       - type: volume
         source: app_logs
         target: /app/logs
@@ -584,7 +580,7 @@ services:
 
 ```toml
 # .replit
-run = "poetry run uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}"
+run = "python -m uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}"
 language = "python3"
 
 [env]
@@ -609,7 +605,7 @@ guessImports = true
 language = "python3"
 
 [deployment]
-run = ["sh", "-c", "poetry run uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}"]
+run = ["sh", "-c", "python -m uvicorn api.app:app --host 0.0.0.0 --port ${PORT:-8080}"]
 deploymentTarget = "cloudrun"
 ```
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,8 +25,5 @@ venv/
 ENV/
 env/
 
-# Exclude Poetry cache and lock files (force fresh resolution)
-poetry.lock
-.poetry/
-~/.cache/pypoetry/
-~/.cache/poetry/ 
+# Exclude pip cache
+~/.cache/pip/

--- a/.replit
+++ b/.replit
@@ -1,6 +1,6 @@
 modules = ["python-3.11", "postgresql-16"]
 hidden = [".pythonlibs"]
-run = "echo 'Starting Uvicorn server...' && poetry run uvicorn api.app:app --host 0.0.0.0 --port 80 --log-level info & sleep 5 && bash scripts/replit_init.sh"
+run = "echo 'Starting Uvicorn server...' && python -m uvicorn api.app:app --host 0.0.0.0 --port 80 --log-level info & sleep 5 && bash scripts/replit_init.sh"
 entrypoint = "api/app.py"
 
 # =============================================
@@ -38,7 +38,7 @@ USE_MOCK_EMBEDDINGS = "false"
 # Deployment Configuration
 # =============================================
 [deployment]
-run = "echo 'Starting Uvicorn server...' && poetry run uvicorn api.app:app --host 0.0.0.0 --port 80 --log-level info & sleep 5 && bash scripts/replit_init.sh"
+run = "echo 'Starting Uvicorn server...' && python -m uvicorn api.app:app --host 0.0.0.0 --port 80 --log-level info & sleep 5 && bash scripts/replit_init.sh"
 deploymentTarget = "cloudrun"
 
 # =============================================
@@ -118,7 +118,7 @@ author = 38779469
 
 [[workflows.workflow.tasks]]
 task = "shell.exec"
-args = "poetry run python scripts/check_replit_db.py"
+args = "python scripts/check_replit_db.py"
 
 [server]
 host = "0.0.0.0"
@@ -127,19 +127,19 @@ port = 80
 # Commands for Replit interface
 [commands.test]
 description = "Run tests in Replit environment"
-command = "poetry run bash scripts/test.sh replit"
+command = "bash scripts/test.sh replit"
 
 [commands.run-api]
 description = "Run the API server"
-command = "poetry run python -m uvicorn api.app:app --host 0.0.0.0 --port 80"
+command = "python -m uvicorn api.app:app --host 0.0.0.0 --port 80"
 
 [commands.update-data]
 description = "Run manual data update"
-command = "poetry run python scripts/scheduled_update.py refresh"
+command = "python scripts/scheduled_update.py refresh"
 
 [commands.check-db]
 description = "Check Replit database connectivity"
-command = "poetry run python scripts/check_replit_db.py"
+command = "python scripts/check_replit_db.py"
 
 [commands.initialize]
 description = "Initialize Replit environment"
@@ -147,32 +147,32 @@ command = "bash scripts/replit_init.sh"
 
 [commands.process-data]
 description = "Process data stratification and embeddings"
-command = "poetry run python scripts/process_data.py"
+command = "python scripts/process_data.py"
 
 [commands.check-data-status]
 description = "Check the status of data processing pipeline"
-command = "poetry run python scripts/process_data.py --check"
+command = "python scripts/process_data.py --check"
 
 [commands.force-data-refresh]
 description = "Force a complete data refresh including stratification and embeddings"
-command = "poetry run python scripts/process_data.py --force-refresh"
+command = "python scripts/process_data.py --force-refresh"
 
 [commands.test-stratification]
 description = "Test the stratification and embedding processes directly"
-command = "poetry run python scripts/test_stratification.py"
+command = "python scripts/test_stratification.py"
 
 [commands.test-stratification-only]
 description = "Test only the stratification process"
-command = "poetry run python scripts/test_stratification.py --stratification-only"
+command = "python scripts/test_stratification.py --stratification-only"
 
 [commands.test-embeddings-only]
 description = "Test only the embedding generation process"
-command = "poetry run python scripts/test_stratification.py --embeddings-only"
+command = "python scripts/test_stratification.py --embeddings-only"
 
 # Scheduler Commands
 [commands.scheduler-start]
 description = "Start the data scheduler"
-command = "poetry run python scripts/scheduled_update.py refresh --continuous --interval=3600"
+command = "python scripts/scheduled_update.py refresh --continuous --interval=3600"
 
 [commands.scheduler-status]
 description = "Check the status of the data scheduler"

--- a/README.md
+++ b/README.md
@@ -444,10 +444,10 @@ For testing purposes when real data is unavailable or outdated, you can generate
 
 ```bash
 # Generate 1000 rows of synthetic data with timestamps in the past 10 days
-poetry run python scripts/generate_test_data.py
+python scripts/generate_test_data.py
 
 # Generate 5000 rows with specific date range and regenerate stratified sample & embeddings
-poetry run python scripts/generate_test_data.py --num-rows 5000 --start-date 2025-03-01T00:00:00 --end-date 2025-03-30T23:59:59 --regenerate-stratified --regenerate-embeddings
+python scripts/generate_test_data.py --num-rows 5000 --start-date 2025-03-01T00:00:00 --end-date 2025-03-30T23:59:59 --regenerate-stratified --regenerate-embeddings
 ```
 
 You can also adjust the `FILTER_DATE` environment variable to include older test data:
@@ -468,20 +468,20 @@ export FILTER_DATE=2024-04-01  # Include data from April 2024 onwards
 Basic data processing:
 ```bash
 # Process all data stages
-poetry run python scripts/process_data.py
+python scripts/process_data.py
 
 # Check current data status (includes initialization status)
-poetry run python scripts/process_data.py --check
+python scripts/process_data.py --check
 
 # Force refresh all data
-poetry run python scripts/process_data.py --force-refresh
+python scripts/process_data.py --force-refresh
 
 # Regenerate specific components
-poetry run python scripts/process_data.py --regenerate --stratified-only  # Only regenerate stratified sample
-poetry run python scripts/process_data.py --regenerate --embeddings-only  # Only regenerate embeddings
+python scripts/process_data.py --regenerate --stratified-only  # Only regenerate stratified sample
+python scripts/process_data.py --regenerate --embeddings-only  # Only regenerate embeddings
 
 # Advanced options
-poetry run python scripts/process_data.py --ignore-lock  # Bypass process locks (use with caution)
+python scripts/process_data.py --ignore-lock  # Bypass process locks (use with caution)
 ```
 
 ### Process Lock Management
@@ -490,11 +490,11 @@ The system includes a robust process lock management mechanism to prevent duplic
 
 ```bash
 # Test process lock functionality
-poetry run python scripts/test_process_lock.py --all
+python scripts/test_process_lock.py --all
 
 # Test specific lock features
-poetry run python scripts/test_process_lock.py --test-contention  # Test lock contention between processes
-poetry run python scripts/test_process_lock.py --test-marker  # Test initialization markers
+python scripts/test_process_lock.py --test-contention  # Test lock contention between processes
+python scripts/test_process_lock.py --test-marker  # Test initialization markers
 ```
 
 In Replit environments, the lock manager uses Object Storage for persistence across restarts, while in Docker/local environments it uses file-based locks. This ensures that:

--- a/docs/chanscope_implementation.md
+++ b/docs/chanscope_implementation.md
@@ -39,7 +39,7 @@ chmod +x scripts/test_chanscope_implementation.sh
 ./scripts/test_chanscope_implementation.sh
 
 # On Windows
-poetry run python scripts/scheduled_update.py
+python scripts/scheduled_update.py
 ```
 
 2. Test via the API:

--- a/docs/stratification_guide.md
+++ b/docs/stratification_guide.md
@@ -60,7 +60,7 @@ For production environments, schedule regular forced refreshes to ensure your st
 
 ```bash
 # Refresh data and regenerate stratified sample daily
-poetry run python scripts/scheduled_update.py refresh --force-refresh --continuous --interval=86400
+python scripts/scheduled_update.py refresh --force-refresh --continuous --interval=86400
 ```
 
 ### 2. Two-Stage Refresh for Resource Constraints
@@ -69,10 +69,10 @@ In memory-constrained environments, use a two-stage approach:
 
 ```bash
 # First: Regenerate stratified sample only
-poetry run python scripts/scheduled_update.py refresh --force-refresh --skip-embeddings
+python scripts/scheduled_update.py refresh --force-refresh --skip-embeddings
 
 # Later (during off-peak hours): Generate embeddings
-poetry run python scripts/scheduled_update.py embeddings
+python scripts/scheduled_update.py embeddings
 ```
 
 ### 3. Monitoring Stratification Age
@@ -80,7 +80,7 @@ poetry run python scripts/scheduled_update.py embeddings
 Check the age of your stratified sample:
 
 ```bash
-poetry run python scripts/scheduled_update.py status
+python scripts/scheduled_update.py status
 ```
 
 Look for the timestamp in the stratified metadata file to determine when it was last regenerated. A warning sign is when the timestamp is significantly older than your most recent data.
@@ -92,8 +92,8 @@ For advanced use cases, consider implementing different refresh intervals:
 ```bash
 # Process new data hourly, regenerate stratified sample daily
 # Note: This requires a custom implementation using scheduled tasks
-0 * * * * poetry run python scripts/scheduled_update.py refresh
-0 0 * * * poetry run python scripts/scheduled_update.py refresh --force-refresh
+0 * * * * python scripts/scheduled_update.py refresh
+0 0 * * * python scripts/scheduled_update.py refresh --force-refresh
 ```
 
 ## Troubleshooting

--- a/replit.nix
+++ b/replit.nix
@@ -8,17 +8,13 @@
     pkgs.arrow-cpp
     pkgs.glibcLocales
     pkgs.libxcrypt
-    pkgs.python310
-    pkgs.poetry
+    pkgs.python311
     pkgs.nodePackages.pyright
     pkgs.black
-    pkgs.python310Packages.pip
-    pkgs.python310Packages.poetry-core
-    pkgs.python310Packages.virtualenv
+    pkgs.python311Packages.pip
+    pkgs.python311Packages.virtualenv
   ];
   env = {
-    POETRY_VIRTUALENVS_IN_PROJECT = "true";
-    POETRY_VIRTUALENVS_CREATE = "true";
-    PYTHONPATH = "${pkgs.python310}/lib/python3.10/site-packages";
+    PYTHONPATH = "${pkgs.python311}/lib/python3.11/site-packages";
   };
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Chanscope Knowledge Agent Requirements
-# Python 3.10+ required
+# Python 3.11+ required
 
 # Core Web Frameworks
 fastapi>=0.115.0


### PR DESCRIPTION
## Summary
- use Python 3.11 packages in `replit.nix`
- remove Poetry references and update commands to use `python`
- adjust README instructions for pip usage
- update doc examples for pip
- drop Poetry files from `.dockerignore`
- tweak `.replit` run configuration
- mark Python 3.11 requirement in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685558bd2820832e8ded8d848b91b5b6